### PR TITLE
Typing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ $ FLASK_APP=app.py python populate_test_database.py
 
 Some example unit tests are provided in [``tests/``](tests/). They are written
 using the built-in [unit-test](https://docs.python.org/3/library/unittest.html)
-framework.
+framework. **Be sure to change** [``tests/``](tests/tests_mypy.py) to reference
+your python package by change the line `self.pkgname: str = "zero"` to have 
+your package name rather than "zero". 
 
 We use the [nose2](http://nose2.readthedocs.io/en/latest/) test runner, with
 coverage. For example:
@@ -124,6 +126,12 @@ Your code has been rated at 9.49/10 (previous run: 9.41/10, +0.07)
 ## Type hints and static checking
 Use [type hint annotations](https://docs.python.org/3/library/typing.html)
 wherever practicable. Use [mypy](http://mypy-lang.org/) to check your code.
+If you run across typechecking errors in your code and you have a good reason
+for `mypy` to ignore them, you should be able to add `# type: ignore`, 
+ideally along with an actual comment describing why the type checking should be 
+ignored on this line. In cases where it is hoped the types can be specified later,
+just simplying adding the `# type: ignore` without further comment is fine.
+
 
 Try running mypy with (from project root):
 

--- a/lintstats.sh
+++ b/lintstats.sh
@@ -11,7 +11,7 @@ curl -u $USERNAME:$GITHUB_TOKEN \
     > /dev/null 2>&1
 
 
-mypy -p zero --ignore-missing-imports
+mypy -p zero
 MYPY_STATUS=$?
 if [ $MYPY_STATUS -ne 0 ]; then MYPY_STATE="failure" && echo "mypy failed"; else MYPY_STATE="success" &&  echo "mypy passed"; fi
 

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -1,0 +1,38 @@
+"""Tests using mypy."""
+import os
+import glob
+import subprocess
+import unittest
+from typing import Any, Dict, List
+
+
+class MyPyTest(unittest.TestCase):
+    """Class for testing modules with mypy."""
+
+    def test_run_mypy_module(self) -> None:
+        """Run mypy on all module sources."""
+        mypy_call: List[str] = ["mypy"] + self.mypy_opts + ["-p", self.pkgname]
+        result: int = subprocess.call(
+            mypy_call, env=os.environ, cwd=self.pypath)
+        self.assertEqual(result, 0, f'mypy on {self.pkgname}')
+
+    def test_run_mypy_tests(self) -> None:
+        """Run mypy on all tests in module under the tests directory."""
+        for test_file in glob.iglob(f'{os.getcwd()}/tests/**/*.py',
+                                    recursive=True):
+            mypy_call: List[str] = ["mypy"] + self.mypy_opts + [test_file]
+            test_result: int = subprocess.call(
+                mypy_call, env=os.environ, cwd=self.pypath)
+            self.assertEqual(test_result, 0, f'mypy on test {test_file}')
+
+    def __init__(self, *args: str, **kwargs: str) -> None:
+        """Set up some common variables."""
+        self.pkgname: str = "zero"
+        super(MyPyTest, self).__init__(*args, **kwargs)
+        my_env = os.environ.copy()
+        self.pypath: str = my_env.get("PYTHONPATH", os.getcwd())
+        self.mypy_opts: List[str] = [] # should now use mypy.ini for mypy options
+        # self.mypy_opts: List[str] = ['--ignore-missing-imports', '--strict']
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_routes_external_api.py
+++ b/tests/test_routes_external_api.py
@@ -4,26 +4,28 @@ from unittest import TestCase, mock
 from datetime import datetime
 import json
 import jsonschema
+from flask import Flask
 from zero.factory import create_web_app
 import jwt
 
+from typing import Any, Optional
 
-def generate_token(app: object, claims: dict) -> str:
+def generate_token(app: Flask, claims: dict) -> str:
     """Helper function for generating a JWT."""
     secret = app.config.get('JWT_SECRET')
-    return jwt.encode(claims, secret, algorithm='HS256')
+    return jwt.encode(claims, secret, algorithm='HS256') #type: ignore
 
 
 class TestExternalAPIRoutes(TestCase):
     """Sample tests for external API routes."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Initialize the Flask application, and get a client for testing."""
         self.app = create_web_app()
         self.client = self.app.test_client()
 
     @mock.patch('zero.services.baz.retrieve_baz')
-    def test_get_baz(self, mock_retrieve_baz):
+    def test_get_baz(self, mock_retrieve_baz: Any) -> Optional[dict]:
         """Endpoint /zero/api/baz/<int> returns JSON about a Baz."""
         with open('schema/baz.json') as f:
             schema = json.load(f)
@@ -34,7 +36,7 @@ class TestExternalAPIRoutes(TestCase):
         response = self.client.get('/zero/api/baz/1')
 
         expected_data = {'id': foo_data['id'], 'foo': foo_data['foo'],
-                         'created': foo_data['created'].isoformat()}
+                         'created': foo_data['created'].isoformat()} #type: ignore
 
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(json.loads(response.data), expected_data)
@@ -43,9 +45,10 @@ class TestExternalAPIRoutes(TestCase):
             jsonschema.validate(json.loads(response.data), schema)
         except jsonschema.exceptions.SchemaError as e:
             self.fail(e)
+        return foo_data
 
     @mock.patch('zero.services.things.get_a_thing')
-    def test_get_thing(self, mock_get_a_thing):
+    def test_get_thing(self, mock_get_a_thing: Any) -> Optional[dict]:
         """Endpoint /zero/api/thing/<int> returns JSON about a Thing."""
         with open('schema/thing.json') as f:
             schema = json.load(f)
@@ -59,7 +62,7 @@ class TestExternalAPIRoutes(TestCase):
                                    headers={'Authorization': token})
 
         expected_data = {'id': foo_data['id'], 'name': foo_data['name'],
-                         'created': foo_data['created'].isoformat()}
+                         'created': foo_data['created'].isoformat()} #type: ignore
 
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(json.loads(response.data), expected_data)
@@ -68,3 +71,5 @@ class TestExternalAPIRoutes(TestCase):
             jsonschema.validate(json.loads(response.data), schema)
         except jsonschema.exceptions.SchemaError as e:
             self.fail(e)
+
+        return foo_data

--- a/tests/test_routes_ui.py
+++ b/tests/test_routes_ui.py
@@ -3,39 +3,44 @@
 from unittest import TestCase, mock
 from datetime import datetime
 import jwt
+from flask import Flask
 from zero.factory import create_web_app
 
+from typing import Any, Optional
 
-def generate_token(app: object, claims: dict) -> str:
+def generate_token(app: Flask, claims: dict) -> str:
     """Helper function for generating a JWT."""
     secret = app.config.get('JWT_SECRET')
-    return jwt.encode(claims, secret, algorithm='HS256')
+    return jwt.encode(claims, secret, algorithm='HS256') #type: ignore
 
 
 class TestUIRoutes(TestCase):
     """Sample tests for UI routes."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Initialize the Flask application, and get a client for testing."""
         self.app = create_web_app()
         self.client = self.app.test_client()
 
     @mock.patch('zero.services.baz.retrieve_baz')
-    def test_get_baz(self, mock_retrieve_baz):
+    def test_get_baz(self, mock_retrieve_baz: Any) -> Optional[dict]:
         """Endpoint /zero/ui/baz/<int> returns an HTML page about a Baz."""
         foo_data = {'id': 1, 'foo': 'bar', 'created': datetime.now()}
-        mock_retrieve_baz.return_value = foo_data
+        if mock_retrieve_baz is not None:
+            mock_retrieve_baz.return_value = foo_data
 
         response = self.client.get('/zero/ui/baz/1')
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers['Content-Type'],
                          'text/html; charset=utf-8')
+        return foo_data
 
     @mock.patch('zero.services.things.get_a_thing')
-    def test_get_thing(self, mock_get_a_thing):
+    def test_get_thing(self, mock_get_a_thing: Any) -> Optional[dict]:
         """Endpoint /zero/ui/thing/<int> returns HTML page about a Thing."""
         foo_data = {'id': 4, 'name': 'First thing', 'created': datetime.now()}
+
         mock_get_a_thing.return_value = foo_data
 
         token = generate_token(self.app, {'scope': ['read:thing']})
@@ -46,3 +51,4 @@ class TestUIRoutes(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers['Content-Type'],
                          'text/html; charset=utf-8')
+        return foo_data

--- a/tests/test_service_foo.py
+++ b/tests/test_service_foo.py
@@ -6,12 +6,13 @@ import json
 import requests
 from zero.services import baz
 
+from typing import Any, Optional
 
 class TestBazServiceStatus(TestCase):
     """The method :meth:`.status` indicates the status of the Baz service."""
 
     @mock.patch('zero.services.baz.requests.Session')
-    def test_status_returns_true_when_remote_is_ok(self, mock_session):
+    def test_status_returns_true_when_remote_is_ok(self, mock_session: Any) -> None:
         """If the remote baz service is OK, :meth:`.status` returns True."""
         mock_get_response = mock.MagicMock(status_code=200, ok=True)
         mock_get = mock.MagicMock(return_value=mock_get_response)
@@ -23,7 +24,7 @@ class TestBazServiceStatus(TestCase):
         self.assertTrue(bazSession.status())
 
     @mock.patch('zero.services.baz.requests.Session')
-    def test_status_returns_false_when_remote_is_not_ok(self, mock_session):
+    def test_status_returns_false_when_remote_is_not_ok(self, mock_session: Any) -> None:
         """If the remote baz service isn't ok :meth:`.status` returns False."""
         mock_get_response = mock.MagicMock(status_code=503, ok=False)
         mock_get = mock.MagicMock(return_value=mock_get_response)
@@ -35,7 +36,7 @@ class TestBazServiceStatus(TestCase):
         self.assertFalse(bazSession.status())
 
     @mock.patch('zero.services.baz.requests.Session')
-    def test_status_returns_false_when_an_error_occurs(self, mock_session):
+    def test_status_returns_false_when_an_error_occurs(self, mock_session: Any) -> None:
         """If there is a problem calling baz :meth:`.status` returns False."""
         mock_get = mock.MagicMock(side_effect=requests.exceptions.HTTPError)
         mock_session_instance = mock.MagicMock()
@@ -50,7 +51,7 @@ class TestBazServiceRetrieve(TestCase):
     """The method :meth:`.retrieve_baz` is for getting baz."""
 
     @mock.patch('zero.services.baz.requests.Session')
-    def test_returns_none_when_not_found(self, mock_session):
+    def test_returns_none_when_not_found(self, mock_session: Any) -> None:
         """If there is no such baz, returns None."""
         mock_get_response = mock.MagicMock(status_code=404, ok=False)
         mock_get = mock.MagicMock(return_value=mock_get_response)
@@ -62,7 +63,7 @@ class TestBazServiceRetrieve(TestCase):
         self.assertIsNone(bazSession.retrieve_baz(4))
 
     @mock.patch('zero.services.baz.requests.Session')
-    def test_returns_dict_when_valid_json_returned(self, mock_session):
+    def test_returns_dict_when_valid_json_returned(self, mock_session: Any) -> None:
         """If there is a baz, returns the data returned by baz service."""
         mock_json = mock.MagicMock(return_value={'bazdata': 'foo'})
         mock_get_response = mock.MagicMock(status_code=200, ok=True,
@@ -73,10 +74,13 @@ class TestBazServiceRetrieve(TestCase):
         mock_session.return_value = mock_session_instance
 
         bazSession = baz.BazServiceSession('foo')
-        self.assertDictEqual(bazSession.retrieve_baz(4), {'bazdata': 'foo'})
+        bazRetrieval = bazSession.retrieve_baz(4)
+        self.assertIsNotNone(bazRetrieval)
+        if bazRetrieval is not None:
+            self.assertDictEqual(bazRetrieval, {'bazdata': 'foo'})
 
     @mock.patch('zero.services.baz.requests.Session')
-    def test_raises_ioerror_when_status_not_ok(self, mock_session):
+    def test_raises_ioerror_when_status_not_ok(self, mock_session: Any) -> None:
         """If the the baz service returns a bad status, raises IOError."""
         mock_get_response = mock.MagicMock(status_code=500, ok=False)
         mock_get = mock.MagicMock(return_value=mock_get_response)
@@ -89,9 +93,9 @@ class TestBazServiceRetrieve(TestCase):
             bazSession.retrieve_baz(4)
 
     @mock.patch('zero.services.baz.requests.Session')
-    def test_raises_ioerror_when_data_is_bad(self, mock_session):
+    def test_raises_ioerror_when_data_is_bad(self, mock_session: Any) -> None:
         """If the the baz service retrieves non-JSON data, raises IOError."""
-        def raise_decoderror():
+        def raise_decoderror() -> None:
             raise json.decoder.JSONDecodeError('msg', 'doc', 0)
 
         mock_json = mock.MagicMock(side_effect=raise_decoderror)

--- a/zero/services/things.py
+++ b/zero/services/things.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 db: SQLAlchemy = SQLAlchemy()
 
-
 class Thing(db.Model):
     """Model for things."""
 


### PR DESCRIPTION
1. Added `tests_mypy.py` to check both tests and package code for types when `nose2` or other testrunner is used.
2. Fixed associated typing issues.
3. Changed `lintstats.sh` to use whatever `mypyp.ini` is using instead of custom params.