### PR TITLE
short lived sessions in e2e test

### DIFF
--- a/tests/test_e2e_thing_mutation.py
+++ b/tests/test_e2e_thing_mutation.py
@@ -42,6 +42,7 @@ class TestCreateAndMutate(TestCase):
         # Use an in-memory queue, and an on-disk SQLite DB for results.
         celery_app.conf.broker_url = 'memory://localhost/'
         celery_app.conf.result_backend = 'db+sqlite:///results.db'
+        celery_app.conf.database_short_lived_sessions = True
         celery_app.conf.worker_prefetch_multiplier = 1
         celery_app.conf.task_acks_late = True
         celery_app.conf.task_always_eager = False

--- a/tests/test_e2e_thing_mutation.py
+++ b/tests/test_e2e_thing_mutation.py
@@ -41,8 +41,8 @@ class TestCreateAndMutate(TestCase):
 
         # Use an in-memory queue, and an on-disk SQLite DB for results.
         celery_app.conf.broker_url = 'memory://localhost/'
-        celery_app.conf.result_backend = 'db+sqlite:///results.db'
-        celery_app.conf.database_short_lived_sessions = True
+        os.mkdir('/tmp/results')
+        celery_app.conf.result_backend = 'file:///tmp/results'
         celery_app.conf.worker_prefetch_multiplier = 1
         celery_app.conf.task_acks_late = True
         celery_app.conf.task_always_eager = False


### PR DESCRIPTION
Set ``database_short_lived_sessions=True`` in Celery config for e2e test, hoping to resolve intermittent locking of the result db (Sqlite3). Sqlite isn't great for asynchronous stuff, but hoping to be able to keep it just for demo purposes.