### PR TITLE
adding scoped_session to ignored_classes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -236,7 +236,7 @@ ignore-on-opaque-inference=yes
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,scoped_session
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime


### PR DESCRIPTION
pylint doesn't catch these generated sources, so the must be ignored to pass.